### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/matanbaruch/cursor-admin-api-exporter/security/code-scanning/4](https://github.com/matanbaruch/cursor-admin-api-exporter/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the workflow file, ensuring only the least privilege required for all jobs is granted. Since none of the jobs require write permissions and only need to read repository contents, set `permissions: contents: read` at the workflow level (top of the file, after `name:` and before `on:`). This restricts the GITHUB_TOKEN permissions for all jobs in the workflow. No further changes to individual jobs are needed unless specific jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
