### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/matanbaruch/cursor-admin-api-exporter/security/code-scanning/1](https://github.com/matanbaruch/cursor-admin-api-exporter/security/code-scanning/1)

The best way to fix this problem is to explicitly set the `permissions` key at the workflow or job level to restrict the GitHub Actions token to the minimum required privileges. Since all jobs in this workflow only read the repository contents (none of them need to write, create pull requests, or interact with issues), setting `permissions: contents: read` at the workflow (top) level is sufficient and best practice. This will apply to all jobs unless a job specifies its own `permissions`. No additional imports or external methods are needed; this is a YAML configuration change.

To implement the fix, add the following at the very top of the workflow file, after the `name:` field, and before the `on:` field:

```yaml
permissions:
  contents: read
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
